### PR TITLE
Updated the response of transaction endpoint 

### DIFF
--- a/src/transaction/transaction.service.ts
+++ b/src/transaction/transaction.service.ts
@@ -28,7 +28,7 @@ export class TransactionService {
       _id: transactionId ? new Types.ObjectId(transactionId) : undefined,
       ...transactionData,
     });
-    await newTransaction.save();
+    const savedTransaction = await newTransaction.save();
     const { creator, group, _id: relatedId } = newTransaction;
     this.activityFeedService.createActivity({
       _id:createTransactionDto.activityId,
@@ -42,8 +42,9 @@ export class TransactionService {
     await this.balanceService.updateBalancesAfterTransaction(
       createTransactionDto,
     );
+    const transactionHistory= await this.balanceService.findAll(creator);
 
-    return newTransaction;
+    return {...savedTransaction.toObject(),transactionHistory:transactionHistory};
   }
 
   async getTransaction(transactionId) {


### PR DESCRIPTION
Previously, the only response being sent contained information about the new transaction. Now, I have added transaction history to the response as well.